### PR TITLE
프론트엔드 헤더 모달창 추가

### DIFF
--- a/web/components/AlarmModal.vue
+++ b/web/components/AlarmModal.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="alarm">
+    <div class="alarm__title">
+      <span>내 알람</span>
+      <span class="close-btn" @click="$emit('closeAlarmModal')"
+        ><i class="fas fa-times"></i
+      ></span>
+    </div>
+    <hr />
+    <ul class="alarm__content">
+      <li>
+        <span>새로운 댓글이 있습니다.</span>
+        <span class="alarm__timestamp"> 2021-10-04 </span>
+      </li>
+    </ul>
+  </div>
+</template>
+<script>
+export default {}
+</script>
+<style lang="scss" scoped>
+.alarm {
+  box-sizing: border-box;
+  width: 100vw;
+  height: 100vh;
+  padding: 0 16px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: $white;
+  z-index: 999;
+
+  hr {
+    color: $gray;
+    margin: 0 auto;
+  }
+
+  &__title {
+    height: 57px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: $heading;
+
+    .close-btn {
+      position: absolute;
+      right: 16px;
+    }
+  }
+  &__content {
+    padding: 16px 0;
+
+    li {
+      list-style-type: disc;
+      list-style-position: inside;
+      color: $yellow;
+      position: relative;
+
+      span {
+        color: $black;
+      }
+
+      span:last-child {
+        color: $gray;
+        font-size: $description;
+        position: absolute;
+        right: 0;
+        bottom: 0;
+      }
+    }
+  }
+}
+</style>

--- a/web/components/Header.vue
+++ b/web/components/Header.vue
@@ -1,16 +1,34 @@
 <template>
-  <header class="header">
-    <div class="header__title">
-      <NuxtLink to="/">AI CARE</NuxtLink>
-    </div>
-    <div class="header__alarm">
-      <span><i class="far fa-bell"></i></span>
-      <div class="alarm-circle"></div>
-    </div>
-  </header>
+  <div>
+    <header class="header">
+      <div class="header__title">
+        <NuxtLink to="/">AI CARE</NuxtLink>
+      </div>
+      <div class="header__alarm">
+        <span @click="showAlarmModal"><i class="far fa-bell"></i></span>
+        <div class="alarm-circle"></div>
+      </div>
+    </header>
+    <alarm-modal v-if="isModalOpened" @closeAlarmModal="isModalOpened=false" />
+  </div>
 </template>
+
 <script>
-export default {}
+import AlarmModal from './AlarmModal.vue'
+
+export default {
+  components: { AlarmModal },
+  data() {
+    return {
+      isModalOpened: false,
+    }
+  },
+  methods: {
+    showAlarmModal() {
+      this.isModalOpened = true
+    },
+  },
+}
 </script>
 <style lang="scss" scoped>
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap');
@@ -20,20 +38,18 @@ export default {}
   justify-content: space-between;
   align-items: center;
   border-radius: 0px 0px 5px 5px;
-  // box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
-  // box-shadow: 0px 3px 15px 2px rgba(155, 155, 155, 0.6);
-  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
-  // background-color: $gray;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px,
+    rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   color: $gray;
 
   &__title {
     font-weight: 700;
-    font-size: 24px;
+    font-size: $heading;
     font-family: 'Caveat', cursive;
   }
 
   &__alarm {
-    font-size: 24px;
+    font-size: $heading;
     position: relative;
 
     .alarm-circle {
@@ -44,7 +60,6 @@ export default {}
       height: 7px;
       border-radius: 50%;
       background-color: $yellow;
-
     }
   }
 

--- a/web/components/Header.vue
+++ b/web/components/Header.vue
@@ -9,7 +9,12 @@
         <div class="alarm-circle"></div>
       </div>
     </header>
-    <alarm-modal v-if="isModalOpened" @closeAlarmModal="isModalOpened=false" />
+    <transition name="modalSlide">
+      <alarm-modal
+        v-if="isModalOpened"
+        @closeAlarmModal="isModalOpened = false"
+      />
+    </transition>
   </div>
 </template>
 
@@ -18,6 +23,7 @@ import AlarmModal from './AlarmModal.vue'
 
 export default {
   components: { AlarmModal },
+  transition: 'modalSlide',
   data() {
     return {
       isModalOpened: false,
@@ -32,6 +38,7 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap');
+
 .header {
   padding: 16px;
   display: flex;
@@ -67,5 +74,31 @@ export default {
     text-decoration: none;
     color: $gray;
   }
+}
+
+.modalSlide-enter-active,
+.modalSlide-leave-active {
+  position: absolute;
+  transition: all 0.2s ease-in-out;
+}
+
+.modalSlide-enter {
+  top: 100%;
+  opacity: 0;
+}
+
+.modalSlide-enter-to {
+  top: 0;
+  opacity: 1;
+}
+
+.modalSlide-leave {
+  top: 0;
+  opacity: 1;
+}
+
+.modalSlide-leave-to {
+  top: 100%;
+  opacity: 0;
 }
 </style>

--- a/web/components/Header.vue
+++ b/web/components/Header.vue
@@ -6,14 +6,11 @@
       </div>
       <div class="header__alarm">
         <span @click="showAlarmModal"><i class="far fa-bell"></i></span>
-        <div class="alarm-circle"></div>
+        <div v-if="isAlarmExist" class="alarm-circle"></div>
       </div>
     </header>
     <transition name="modalSlide">
-      <alarm-modal
-        v-if="isModalOpened"
-        @closeAlarmModal="isModalOpened = false"
-      />
+      <alarm-modal v-if="isModalOpen" @closeAlarmModal="isModalOpen = false" />
     </transition>
   </div>
 </template>
@@ -26,12 +23,13 @@ export default {
   transition: 'modalSlide',
   data() {
     return {
-      isModalOpened: false,
+      isModalOpen: false,
+      isAlarmExist: true,
     }
   },
   methods: {
     showAlarmModal() {
-      this.isModalOpened = true
+      if (this.isAlarmExist) this.isModalOpen = true
     },
   },
 }


### PR DESCRIPTION
헤더의 알림 탭을 클릭하면 모달창이 오픈되도록 만들었습니다.
알람이 없을 때는 오픈되지 않도록 했습니다.
추후에 알람의 유무와 알람 내용을 가져와서 연동하면 됩니다.